### PR TITLE
Remove unused buttons (favorite, report, not interested)

### DIFF
--- a/resources/js/components/advertOptions.ts
+++ b/resources/js/components/advertOptions.ts
@@ -28,6 +28,12 @@ class JobOptions {
 
         // open the dropdown 
         document.querySelectorAll('.advert-options').forEach(button => {
+            if (!this.can('update', button) && !this.can('delete', button)) {
+                // if user cannot delete or edit the advert, hide the options menu
+                button.classList.add('hidden');
+                return;
+            }
+
             button.addEventListener('click', event => {
                 // if click is inside the dropdown, don't prevent the event
                 if (findParent(event.target as Element, parent => parent.id === this.dropdown.id)) {
@@ -114,16 +120,24 @@ class JobOptions {
         if (advertId === null)
             return;
 
-        if (element.classList.contains('can-update')) {
+        if (this.can('update', element)) {
             // set the correct route link for advert editing
             this.editItem.href = this.editItem.href.replace(/\/\d+\/edit$/, `/${advertId}/edit`);
             this.editItem.classList.remove('hidden');
         }
-        if (element.classList.contains('can-delete')) {
+        if (this.can('delete', element)) {
             // set the correct route link for advert deletion
             this.deleteItem.action = this.deleteItem.action.replace(/\/\d+$/, `/${advertId}`);
             this.deleteItem.classList.remove('hidden');
         }
+    }
+
+    /**
+     * @returns Whether the user is permitted the perform this action
+     * on the advert assigned to the given element.
+     */
+    private can(action: 'update' | 'delete', element: Element): boolean {
+        return element.classList.contains(`can-${action}`);
     }
 
     /**

--- a/resources/views/components/advert-options.blade.php
+++ b/resources/views/components/advert-options.blade.php
@@ -17,22 +17,22 @@ $itemClass = "$itemClassBase flex flex-row p-2 items-end gap-2";
     <div class="py-1" role="none">
 
         {{-- Favorite Ad Button --}}
-        <a href="?favorite" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-favorite">
+        {{-- <a href="?favorite" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-favorite">
             @svg('resources/images/star.svg', 'fill-gray-500')
             @tr('advert.favorite')
-        </a>
+        </a> --}}
 
         {{-- Hide Ad Button --}}
-        <a href="?not-interested" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-hide">
+        {{-- <a href="?not-interested" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-hide">
             @svg('resources/images/delete.svg', 'fill-gray-500')
             @tr('advert.hide')
-        </a>
+        </a> --}}
 
         {{-- Report Ad Button --}}
-        <a href="?report" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-report">
+        {{-- <a href="?report" class="{{ $itemClass }}" role="menuitem" tabindex="-1" id="advert-options-report">
             @svg('resources/images/flag.svg', 'fill-gray-500')
             @tr('advert.report')
-        </a>
+        </a> --}}
 
         {{-- # PRIVILEDGED ACTIONS # --}}
         {{-- the actions below require specific permissions for each advert, --}}

--- a/resources/views/components/job-advert.blade.php
+++ b/resources/views/components/job-advert.blade.php
@@ -63,11 +63,11 @@
                 href="{{ route('jobs.apply.create', $id) }}">
                 @tr('advert.apply')
             </x-primary-link>
-            <button id="{{ 'advert-' . $id . '-fav' }}" title="{{ __('advert.favorite') }}" type="button"
+            {{-- <button id="{{ 'advert-' . $id . '-fav' }}" title="{{ __('advert.favorite') }}" type="button"
                 aria-label="save to favorites"
                 class="group bg-slate-400 rounded-xl p-2 text-sm flex items-center justify-center whitespace-nowrap font-semibold">
                 @svg('resources/images/star-outline.svg', 'fill-white group-hover:fill-yellow-200 ease-in-out duration-150')
-            </button>
+            </button> --}}
         </span>
     </x-exclusive-details>
 </div>


### PR DESCRIPTION
The 'three dots' options menu on adverts will not be shown if the user does not have either edit or delete permissions on the advert.

Closes #56